### PR TITLE
Added `prep_conditionals` function call

### DIFF
--- a/ee2/third_party/fieldpack/fieldpack_fieldtype.php
+++ b/ee2/third_party/fieldpack/fieldpack_fieldtype.php
@@ -635,6 +635,15 @@ class Fieldpack_Multi_Fieldtype extends Fieldpack_Fieldtype {
 					$option_tagdata = $this->EE->TMPL->swap_var_single('option_value', $option_name, $option_tagdata);
 					$option_tagdata = $this->EE->TMPL->swap_var_single('option_label', $option, $option_tagdata);
 
+
+                                        // use EE to prep the conditional statements properly
+                                        $option_tagdata = ee()->functions->prep_conditionals($option_tagdata, array(
+                                            'option' => $option,
+                                            'option_name' => $option_name,
+                                            'option_value' => $option_name,
+                                            'option_label' => $option,
+                                        ));
+
 					// parse {switch} and {count} tags
 					$this->parse_iterators($option_tagdata);
 


### PR DESCRIPTION
I needed to add the `prep_conditionals` function call to the Fieldpack_Multi_Fieldtype class to make sure that EE processes the conditional statements correctly in more recent versions. This relates to Derek Jones' note here: https://support.ellislab.com/bugs/detail/20437/#13179
